### PR TITLE
close map file to allow repeat agent loads

### DIFF
--- a/perf-map-agent.c
+++ b/perf-map-agent.c
@@ -36,6 +36,10 @@ void ensure_open() {
     if (!method_file)
         method_file = perf_map_open(getpid());
 }
+void ensure_closed() {
+    perf_map_close(method_file);
+    method_file = NULL;
+}
 
 static int get_line_number(jvmtiLineNumberEntry *table, jint entry_count, jlocation loc) {
   int i;
@@ -190,6 +194,7 @@ Agent_OnAttach(JavaVM *vm, char *options, void *reserved) {
     (*jvmti)->GenerateEvents(jvmti, JVMTI_EVENT_DYNAMIC_CODE_GENERATED);
     (*jvmti)->GenerateEvents(jvmti, JVMTI_EVENT_COMPILED_METHOD_LOAD);
     set_notification_mode(jvmti, JVMTI_DISABLE);
+    ensure_closed();
 
     // FAIL to get the JVM to maybe unload this lib (untested)
     return 1;

--- a/perf-map-file.c
+++ b/perf-map-file.c
@@ -29,6 +29,10 @@ FILE *perf_map_open(pid_t pid) {
     return fopen(filename, "w");
 }
 
+int perf_map_close(FILE *fp) {
+	return fclose(fp);
+}
+
 void perf_map_write_entry(FILE *method_file, const void* code_addr, unsigned int code_size, const char* entry) {
     fprintf(method_file, "%lx %x %s\n", (unsigned long) code_addr, code_size, entry);
     fflush(method_file);


### PR DESCRIPTION
This allows the map file to be created more than once.
