### PR TITLE
Dont call sudo from the scripts.

### DIFF
--- a/bin/create-java-perf-map.sh
+++ b/bin/create-java-perf-map.sh
@@ -2,6 +2,11 @@
 set -e
 #set -x
 
+if [[ $EUID -ne 0 ]]; then
+   echo "This script must be run as root" 1>&2
+   exit 1
+fi
+
 CUR_DIR=`pwd`
 PID=$1
 OPTIONS=$2
@@ -17,6 +22,6 @@ fi
 [ -d $JAVA_HOME ] || JAVA_HOME=/etc/alternatives/java_sdk
 [ -d $JAVA_HOME ] || (echo "JAVA_HOME directory at '$JAVA_HOME' does not exist." && false)
 
-sudo rm $PERF_MAP_FILE -f
+rm $PERF_MAP_FILE -f
 (cd $PERF_MAP_DIR/out && java -cp $ATTACH_JAR_PATH:$JAVA_HOME/lib/tools.jar net.virtualvoid.perf.AttachOnce $PID $OPTIONS)
-sudo chown root:root $PERF_MAP_FILE
+chown root:root $PERF_MAP_FILE

--- a/bin/perf-java-flames
+++ b/bin/perf-java-flames
@@ -2,6 +2,11 @@
 set -e
 #set -x
 
+if [[ $EUID -ne 0 ]]; then
+   echo "This script must be run as root" 1>&2
+   exit 1
+fi
+
 PID=$1
 
 if [ -z $PERF_JAVA_TMP ]; then
@@ -30,6 +35,6 @@ if [ -z $PERF_FLAME_OUTPUT ]; then
 fi
 
 $PERF_MAP_DIR/bin/perf-java-record-stack $*
-sudo perf script -i $PERF_DATA_FILE > $STACKS
+perf script -i $PERF_DATA_FILE > $STACKS
 $FLAMEGRAPH_DIR/stackcollapse-perf.pl $STACKS | tee $COLLAPSED | $FLAMEGRAPH_DIR/flamegraph.pl --color=java > $PERF_FLAME_OUTPUT
 echo "Flame graph SVG written to PERF_FLAME_OUTPUT='`readlink -f $PERF_FLAME_OUTPUT`'."

--- a/bin/perf-java-record-stack
+++ b/bin/perf-java-record-stack
@@ -2,6 +2,11 @@
 set -e
 #set -x
 
+if [[ $EUID -ne 0 ]]; then
+   echo "This script must be run as root" 1>&2
+   exit 1
+fi
+
 PERF_MAP_DIR=$(dirname $(readlink -f $0))/..
 PID=$1
 
@@ -22,5 +27,5 @@ if [ -z $PERF_DATA_FILE ]; then
 fi
 
 echo "Recording events for $PERF_RECORD_SECONDS seconds (adapt by setting PERF_RECORD_SECONDS)"
-sudo perf record -F $PERF_RECORD_FREQ -o $PERF_DATA_FILE -g -p $* -- sleep $PERF_RECORD_SECONDS
+perf record -F $PERF_RECORD_FREQ -o $PERF_DATA_FILE -g -p $* -- sleep $PERF_RECORD_SECONDS
 $PERF_MAP_DIR/bin/create-java-perf-map.sh $PID $PERF_MAP_OPTIONS

--- a/bin/perf-java-report-stack
+++ b/bin/perf-java-report-stack
@@ -2,6 +2,11 @@
 set -e
 #set -x
 
+if [[ $EUID -ne 0 ]]; then
+   echo "This script must be run as root" 1>&2
+   exit 1
+fi
+
 PID=$1
 PERF_MAP_DIR=$(dirname $(readlink -f $0))/..
 
@@ -14,4 +19,4 @@ if [ -z $PERF_DATA_FILE ]; then
 fi
 
 $PERF_MAP_DIR/bin/perf-java-record-stack $*
-sudo perf report -i $PERF_DATA_FILE
+perf report -i $PERF_DATA_FILE

--- a/bin/perf-java-top
+++ b/bin/perf-java-top
@@ -2,8 +2,13 @@
 set -e
 #set -x
 
+if [[ $EUID -ne 0 ]]; then
+   echo "This script must be run as root" 1>&2
+   exit 1
+fi
+
 PERF_MAP_DIR=$(dirname $(readlink -f $0))/..
 
 PID=$1
 $PERF_MAP_DIR/bin/create-java-perf-map.sh $PID $PERF_MAP_OPTIONS
-sudo perf top -p $*
+perf top -p $*


### PR DESCRIPTION
The reason we'd like to avoid using `sudo` is that we are executing this inside a docker container that doesn't have it installed.
