### PR TITLE
support longer class/method names

### DIFF
--- a/src/c/perf-map-agent.c
+++ b/src/c/perf-map-agent.c
@@ -92,7 +92,7 @@ static void sig_string(jvmtiEnv *jvmti, jmethodID method, char *output, size_t n
 }
 
 void generate_single_entry(jvmtiEnv *jvmti, jmethodID method, const void *code_addr, jint code_size) {
-    char entry[100];
+    char entry[128];
     sig_string(jvmti, method, entry, sizeof(entry));
     perf_map_write_entry(method_file, code_addr, code_size, entry);
 }


### PR DESCRIPTION
We bump into the 100 char limit, eg:

"com/netflix/streaming/content/core/internal/processing/streams/predicates/ConfigurableStreamInclus"

128 might be enough.