### PR TITLE
Show Source Location in Map

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Environment variables:
  - `PERF_JAVA_TMP`: the directory to put temporary files in, the default is `/tmp`
  - `PERF_DATA_FILE`: the file name where `perf-java-record-stack` will output performance data into, the default is `$PERF_JAVA_TMP/perf-<pid>.data`
  - `PERF_FLAME_OUTPUT`: the file name to which the flamegraph SVG will be written, the default is `flamegraph-<pid>.svg`
+ - `PERF_FLAME_OPTS`: options to pass to flamegraph.pl (found in FLAMEGRAPH_DIR), the default is  `--color java`
 
 ## Options
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ You can add a comma separated list of options to `perf-java` (or the `AttachOnce
  - `unfoldsimple`: similar to `unfold`, however, the extra entries do not include the " in &lt;root_method&gt;" part
  - `msig`: include full method signature in the name string
  - `dottedclass`: convert class signature (`Ljava/lang/Class;`) to the usual class names with segments separated by dots (`java.lang.Class`). NOTE: this currently breaks coloring when used in combination with [flamegraphs](https://github.com/brendangregg/FlameGraph).
+ - `showsource`: Adds the name of the source file and the line number on which it is declared for each method. Useful when profiling Scala applications that crate a lot of synthetic classes and methods. Does not work with native methods.
 
 ## Known Issues
 

--- a/bin/create-java-perf-map.sh
+++ b/bin/create-java-perf-map.sh
@@ -10,12 +10,12 @@ PERF_MAP_DIR=$(dirname $(readlink -f $0))/..
 ATTACH_JAR_PATH=$PERF_MAP_DIR/out/$ATTACH_JAR
 PERF_MAP_FILE=/tmp/perf-$PID.map
 
-if [ -z $JAVA_HOME ]; then
+if [ -z "$JAVA_HOME" ]; then
   JAVA_HOME=/usr/lib/jvm/default-java
 fi
 
-[ -d $JAVA_HOME ] || JAVA_HOME=/etc/alternatives/java_sdk
-[ -d $JAVA_HOME ] || (echo "JAVA_HOME directory at '$JAVA_HOME' does not exist." && false)
+[ -d "$JAVA_HOME" ] || JAVA_HOME=/etc/alternatives/java_sdk
+[ -d "$JAVA_HOME" ] || (echo "JAVA_HOME directory at '$JAVA_HOME' does not exist." && false)
 
 sudo rm $PERF_MAP_FILE -f
 (cd $PERF_MAP_DIR/out && java -cp $ATTACH_JAR_PATH:$JAVA_HOME/lib/tools.jar net.virtualvoid.perf.AttachOnce $PID $OPTIONS)

--- a/bin/create-links-in
+++ b/bin/create-links-in
@@ -5,7 +5,7 @@ set -e
 TARGET_DIR=$1
 BIN_DIR=`dirname $0`
 
-if [ -z $TARGET_DIR ]; then
+if [ -z "$TARGET_DIR" ]; then
   echo "Please specify a target directory."
   exit
 fi

--- a/bin/perf-java-flames
+++ b/bin/perf-java-flames
@@ -4,7 +4,7 @@ set -e
 
 PID=$1
 
-if [ -z $PERF_JAVA_TMP ]; then
+if [ -z "$PERF_JAVA_TMP" ]; then
   PERF_JAVA_TMP=/tmp
 fi
 
@@ -12,24 +12,24 @@ STACKS=$PERF_JAVA_TMP/out-$PID.stacks
 COLLAPSED=$PERF_JAVA_TMP/out-$PID.collapsed
 PERF_MAP_DIR=$(dirname $(readlink -f $0))/..
 
-#if [ -n $FLAMEGRAPH_DIR ]; then
-#   FLAMEGRAPH_DIR=/home/johannes/git/opensource/FlameGraph
-#fi
-
-if [ ! -x $FLAMEGRAPH_DIR/stackcollapse-perf.pl ]; then
+if [ ! -x "$FLAMEGRAPH_DIR/stackcollapse-perf.pl" ]; then
   echo "FlameGraph executable not found at '$FLAMEGRAPH_DIR/stackcollapse-perf.pl'. Please set FLAMEGRAPH_DIR to the root of the clone of https://github.com/brendangregg/FlameGraph."
   exit
 fi
 
-if [ -z $PERF_DATA_FILE ]; then
+if [ -z "$PERF_DATA_FILE" ]; then
   PERF_DATA_FILE=$PERF_JAVA_TMP/perf-$PID.data
 fi
 
-if [ -z $PERF_FLAME_OUTPUT ]; then
+if [ -z "$PERF_FLAME_OUTPUT" ]; then
   PERF_FLAME_OUTPUT=flamegraph-$PID.svg
+fi
+
+if [ -z "$PERF_FLAME_OPTS" ]; then
+    PERF_FLAME_OPTS="--color=java"
 fi
 
 $PERF_MAP_DIR/bin/perf-java-record-stack $*
 sudo perf script -i $PERF_DATA_FILE > $STACKS
-$FLAMEGRAPH_DIR/stackcollapse-perf.pl $STACKS | tee $COLLAPSED | $FLAMEGRAPH_DIR/flamegraph.pl --color=java > $PERF_FLAME_OUTPUT
+$FLAMEGRAPH_DIR/stackcollapse-perf.pl $STACKS | tee $COLLAPSED | $FLAMEGRAPH_DIR/flamegraph.pl $PERF_FLAME_OPTS > $PERF_FLAME_OUTPUT
 echo "Flame graph SVG written to PERF_FLAME_OUTPUT='`readlink -f $PERF_FLAME_OUTPUT`'."

--- a/bin/perf-java-record-stack
+++ b/bin/perf-java-record-stack
@@ -5,19 +5,19 @@ set -e
 PERF_MAP_DIR=$(dirname $(readlink -f $0))/..
 PID=$1
 
-if [ -z $PERF_JAVA_TMP ]; then
+if [ -z "$PERF_JAVA_TMP" ]; then
   PERF_JAVA_TMP=/tmp
 fi
 
-if [ -z $PERF_RECORD_SECONDS ]; then
+if [ -z "$PERF_RECORD_SECONDS" ]; then
   PERF_RECORD_SECONDS=15
 fi
 
-if [ -z $PERF_RECORD_FREQ ]; then
+if [ -z "$PERF_RECORD_FREQ" ]; then
   PERF_RECORD_FREQ=99
 fi
 
-if [ -z $PERF_DATA_FILE ]; then
+if [ -z "$PERF_DATA_FILE" ]; then
   PERF_DATA_FILE=$PERF_JAVA_TMP/perf-$PID.data
 fi
 

--- a/bin/perf-java-report-stack
+++ b/bin/perf-java-report-stack
@@ -5,11 +5,11 @@ set -e
 PID=$1
 PERF_MAP_DIR=$(dirname $(readlink -f $0))/..
 
-if [ -z $PERF_JAVA_TMP ]; then
+if [ -z "$PERF_JAVA_TMP" ]; then
   PERF_JAVA_TMP=/tmp
 fi
 
-if [ -z $PERF_DATA_FILE ]; then
+if [ -z "$PERF_DATA_FILE" ]; then
   PERF_DATA_FILE=$PERF_JAVA_TMP/perf-$PID.data
 fi
 

--- a/src/c/perf-map-agent.c
+++ b/src/c/perf-map-agent.c
@@ -34,6 +34,7 @@ FILE *method_file = NULL;
 int unfold_inlined_methods = 0;
 int unfold_simple = 0;
 int print_method_signatures = 0;
+int print_source_loc = 0;
 int clean_class_names = 0;
 
 void open_map_file() {
@@ -69,26 +70,62 @@ void class_name_from_sig(char *dest, size_t dest_size, const char *sig) {
 }
 
 static void sig_string(jvmtiEnv *jvmti, jmethodID method, char *output, size_t noutput) {
-    char *name;
-    char *msig;
+    char *sourcefile = NULL;
+    char *name = NULL;
+    char *msig = NULL;
+    char *csig = NULL;
+    jvmtiLineNumberEntry *lines = NULL;
+
     jclass class;
-    char *csig;
+    jvmtiError error = 0;
+    jint entrycount = 0;
+    int lineno = -1;
 
-    (*jvmti)->GetMethodName(jvmti, method, &name, &msig, NULL);
-    (*jvmti)->GetMethodDeclaringClass(jvmti, method, &class);
-    (*jvmti)->GetClassSignature(jvmti, class, &csig, NULL);
+    if((*jvmti)->GetMethodName(jvmti, method, &name, &msig, NULL)) {
+      msig = NULL;
+      name = NULL;
+    }
 
-    char class_name[2000];
-    class_name_from_sig(class_name, sizeof(class_name), csig);
+    // need to set csig to NULL if GetClassSignature fails, but we can't even call
+    // GetClassSignature unless GetMethodDeclaringClass succeeds.
+    if(! (*jvmti)->GetMethodDeclaringClass(jvmti, method, &class) && (*jvmti)->GetClassSignature(jvmti, class, &csig, NULL)) {
+      csig = NULL;
+    }
 
-    if (print_method_signatures)
+    if(print_source_loc) {
+      if((*jvmti)->GetSourceFileName(jvmti, class, &sourcefile)) {
+        sourcefile = NULL;
+      }
+
+      if((*jvmti)->GetLineNumberTable(jvmti, method, &entrycount, &lines)) {
+        lines = NULL;
+      }
+      else if(entrycount > 0) {
+        lineno = lines[0].line_number;
+      }
+    }
+
+    if(csig != NULL) {
+      char class_name[2000];
+      class_name_from_sig(class_name, sizeof(class_name), csig);
+
+      if(print_method_signatures && sourcefile != NULL) {
+        snprintf(output, noutput, "%s.%s%s(%s:%d)", class_name, name, msig, sourcefile, lineno);
+      }
+      else if(print_method_signatures)
         snprintf(output, noutput, "%s.%s%s", class_name, name, msig);
-    else
+      else if(sourcefile != NULL) {
+        snprintf(output, noutput, "%s.%s(%s:%d)", class_name, name, sourcefile, lineno);
+      }
+      else
         snprintf(output, noutput, "%s.%s", class_name, name);
+    }
 
-    (*jvmti)->Deallocate(jvmti, name);
-    (*jvmti)->Deallocate(jvmti, msig);
-    (*jvmti)->Deallocate(jvmti, csig);
+    if(sourcefile != NULL) (*jvmti)->Deallocate(jvmti, sourcefile);
+    if(lines != NULL) (*jvmti)->Deallocate(jvmti, (unsigned char*) lines);
+    if(name != NULL) (*jvmti)->Deallocate(jvmti, name);
+    if(msig != NULL) (*jvmti)->Deallocate(jvmti, msig);
+    if(csig != NULL) (*jvmti)->Deallocate(jvmti, csig);
 }
 
 void generate_single_entry(jvmtiEnv *jvmti, jmethodID method, const void *code_addr, jint code_size) {
@@ -218,6 +255,7 @@ Agent_OnAttach(JavaVM *vm, char *options, void *reserved) {
     unfold_simple = strstr(options, "unfoldsimple") != NULL;
     unfold_inlined_methods = strstr(options, "unfold") != NULL || unfold_simple;
     print_method_signatures = strstr(options, "msig") != NULL;
+    print_source_loc = strstr(options, "showsource") != NULL;
     clean_class_names = strstr(options, "dottedclass") != NULL;
 
     jvmtiEnv *jvmti;
@@ -230,7 +268,6 @@ Agent_OnAttach(JavaVM *vm, char *options, void *reserved) {
     set_notification_mode(jvmti, JVMTI_DISABLE);
     close_map_file();
 
-    // FAIL to get the JVM to maybe unload this lib (untested)
-    return 1;
+    return 0;
 }
 


### PR DESCRIPTION
I've been profiling a lot of Scala code with this tool lately (so awesome, thank you!). The Scala compiler creates a lot of synthetic classes and methods, which can make it really hard to figure out where time is being spent when looking at a perf report. For example, you can get names like "`com.foo.App$$anonfun$4$$anon$1.bar`".

This PR adds an option, "`showsource`", which causes the agent to attach the name of the source file and the line on which it was defined to each JVM method in the perf map. To continue the example, the option would change the "name" of the method above to something like "`com.foo.App$$anonfun$4$$anon$1.bar:(App.scala:20)`".

I also cleaned up the shell scripts a bit. In particular, I added an environment variable, `PERF_FLAME_OPTS`, for passing options to `flamegraph.pl`.

