### PR TITLE
sudo to target process UID

### DIFF
--- a/bin/create-java-perf-map.sh
+++ b/bin/create-java-perf-map.sh
@@ -10,6 +10,12 @@ PERF_MAP_DIR=$(dirname $(readlink -f $0))/..
 ATTACH_JAR_PATH=$PERF_MAP_DIR/out/$ATTACH_JAR
 PERF_MAP_FILE=/tmp/perf-$PID.map
 
+if [ ! -d /proc/$PID ]; then
+  echo "PID $PID not found"
+  exit 1
+fi
+TARGET_UID=$(awk '/^Uid:/{print $2}' /proc/$PID/status)
+
 if [ -z "$JAVA_HOME" ]; then
   JAVA_HOME=/usr/lib/jvm/default-java
 fi
@@ -18,5 +24,5 @@ fi
 [ -d "$JAVA_HOME" ] || (echo "JAVA_HOME directory at '$JAVA_HOME' does not exist." && false)
 
 sudo rm $PERF_MAP_FILE -f
-(cd $PERF_MAP_DIR/out && java -cp $ATTACH_JAR_PATH:$JAVA_HOME/lib/tools.jar net.virtualvoid.perf.AttachOnce $PID "$OPTIONS")
+(cd $PERF_MAP_DIR/out && sudo -u \#$TARGET_UID java -cp $ATTACH_JAR_PATH:$JAVA_HOME/lib/tools.jar net.virtualvoid.perf.AttachOnce $PID "$OPTIONS")
 sudo chown root:root $PERF_MAP_FILE


### PR DESCRIPTION
When the user of the PID to attach to is not a sudoer, one would expect
to be able to run the scripts as root (or as a different sudoer user). However due to the JDK bug
https://bugs.openjdk.java.net/browse/JDK-8036559, root cannot attach to
the JVM of another user. To address this, I’ve added a sudo to the
target user, so the scripts can be run as root (or another sudoer). This should be a no-op if you are
already that user.
