### PR TITLE
Add environment var (PERF_COLLAPSE_OPTS) for collapsestack-perf.pl call

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Environment variables:
  - `FLAMEGRAPH_DIR`: the directory into which [@brendangregg's FlameGraph](https://github.com/brendangregg/FlameGraph) has been checked out
  - `PERF_JAVA_TMP`: the directory to put temporary files in, the default is `/tmp`
  - `PERF_DATA_FILE`: the file name where `perf-java-record-stack` will output performance data into, the default is `$PERF_JAVA_TMP/perf-<pid>.data`
+ - `PERF_COLLAPSE_OPTS`: a string of additional flags to pass to stackcollapse-perf.pl (found in FLAMEGRAPH_DIR), (add --inline with unfoldall perfmap) 
  - `PERF_FLAME_OUTPUT`: the file name to which the flamegraph SVG will be written, the default is `flamegraph-<pid>.svg`
  - `PERF_FLAME_OPTS`: options to pass to flamegraph.pl (found in FLAMEGRAPH_DIR), the default is  `--color java`
 

--- a/bin/perf-java-flames
+++ b/bin/perf-java-flames
@@ -31,5 +31,5 @@ fi
 
 $PERF_MAP_DIR/bin/perf-java-record-stack $*
 sudo perf script -i $PERF_DATA_FILE > $STACKS
-$FLAMEGRAPH_DIR/stackcollapse-perf.pl $STACKS | tee $COLLAPSED | $FLAMEGRAPH_DIR/flamegraph.pl $PERF_FLAME_OPTS > $PERF_FLAME_OUTPUT
+$FLAMEGRAPH_DIR/stackcollapse-perf.pl $PERF_COLLAPSE_OPTS $STACKS | tee $COLLAPSED | $FLAMEGRAPH_DIR/flamegraph.pl $PERF_FLAME_OPTS > $PERF_FLAME_OUTPUT
 echo "Flame graph SVG written to PERF_FLAME_OUTPUT='`readlink -f $PERF_FLAME_OUTPUT`'."


### PR DESCRIPTION
Simple patch that allows you to add --inline to the flamegraph.pl for better viz
