### PR TITLE
Require CMake 2.8.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.6)
+cmake_minimum_required (VERSION 2.8.6)
 project (perf-map-agent)
 
 # uncomment to make a debug build (including source positions and symbols)


### PR DESCRIPTION
UseJava was added only in CMake 2.8.6:

https://github.com/Kitware/CMake/commit/5c2106c71eb2a8b4e547b889fdc8aea3aeaad675