### PR TITLE
Remove nonportable GNU code

### DIFF
--- a/src/c/perf-map-file.c
+++ b/src/c/perf-map-file.c
@@ -20,13 +20,7 @@
 
 #include <sys/types.h>
 #include <stdio.h>
-
-#ifdef __APPLE__
 #include <stdlib.h>
-#else
-#include <error.h>
-#endif
-
 #include <errno.h>
 
 #include "perf-map-file.h"
@@ -36,12 +30,8 @@ FILE *perf_map_open(pid_t pid) {
     snprintf(filename, sizeof(filename), "/tmp/perf-%d.map", pid);
     FILE * res = fopen(filename, "w");
     if (!res) {
-#ifdef __APPLE__
         fprintf(stderr, "Couldn't open %s: errno(%d)", filename, errno);
         exit(0);
-#else
-        error(0, errno, "Couldn't open %s.", filename);
-#endif
     }
     return res;
 }


### PR DESCRIPTION
It's not just \_\_APPLE\_\_ that doesn't support this, but POSIX as a whole.
This doesn't seem necessary at all so I just removed it.