### PR TITLE
emit error message when tools.jar is missing

### DIFF
--- a/bin/create-java-perf-map.sh
+++ b/bin/create-java-perf-map.sh
@@ -34,6 +34,7 @@ if [ -z "$JAVA_HOME" ]; then
   fi
 fi
 [ -d "$JAVA_HOME" ] || (echo "JAVA_HOME directory at '$JAVA_HOME' does not exist." && false)
+[ -f "$JAVA_HOME/lib/tools.jar" ] || (echo "'tools.jar' does not present in '$JAVA_HOME/lib'." && false)
 
 
 if [[ "$LINUX" == "1" ]]; then


### PR DESCRIPTION
This very tiny but kind warn to let me aware that the tools.jar is missing

https://github.com/jvm-profiling-tools/perf-map-agent/issues/37