### PR TITLE
only sudo if you aren't already the user running the jvm process

### DIFF
--- a/bin/create-java-perf-map.sh
+++ b/bin/create-java-perf-map.sh
@@ -36,7 +36,7 @@ fi
 [ -d "$JAVA_HOME" ] || (echo "JAVA_HOME directory at '$JAVA_HOME' does not exist." && false)
 
 
-if [[ "$LINUX" == "1" ]]; then
+if [[ "$LINUX" == "1" ]] && [[ $EUID -ne $TARGET_UID ]]; then
   sudo rm $PERF_MAP_FILE -f
   (cd $PERF_MAP_DIR/out && sudo -u \#$TARGET_UID -g \#$TARGET_GID $JAVA_HOME/bin/java -cp $ATTACH_JAR_PATH:$JAVA_HOME/lib/tools.jar net.virtualvoid.perf.AttachOnce $PID "$OPTIONS")
   sudo chown root:root $PERF_MAP_FILE

--- a/bin/perf-java-flames
+++ b/bin/perf-java-flames
@@ -30,6 +30,6 @@ if [ -z "$PERF_FLAME_OPTS" ]; then
 fi
 
 $PERF_MAP_DIR/bin/perf-java-record-stack $*
-sudo perf script -i $PERF_DATA_FILE > $STACKS
+sudo perf script --force -i $PERF_DATA_FILE > $STACKS
 $FLAMEGRAPH_DIR/stackcollapse-perf.pl $PERF_COLLAPSE_OPTS $STACKS | tee $COLLAPSED | $FLAMEGRAPH_DIR/flamegraph.pl $PERF_FLAME_OPTS > $PERF_FLAME_OUTPUT
 echo "Flame graph SVG written to PERF_FLAME_OUTPUT='`readlink -f $PERF_FLAME_OUTPUT`'."

--- a/bin/perf-java-report-stack
+++ b/bin/perf-java-report-stack
@@ -14,4 +14,4 @@ if [ -z "$PERF_DATA_FILE" ]; then
 fi
 
 $PERF_MAP_DIR/bin/perf-java-record-stack $*
-sudo perf report -i $PERF_DATA_FILE
+sudo perf report --force -i $PERF_DATA_FILE

--- a/bin/perf-java-top
+++ b/bin/perf-java-top
@@ -6,4 +6,4 @@ PERF_MAP_DIR=$(dirname $(readlink -f $0))/..
 
 PID=$1
 $PERF_MAP_DIR/bin/create-java-perf-map.sh $PID "$PERF_MAP_OPTIONS"
-sudo perf top -p $*
+sudo perf top --force -p $*


### PR DESCRIPTION
this enables usage inside docker containers that don't contain sudo, when running `docker exec` as the user running the jvm process

eg: when perf-map-agent is installed at `/perf-map-agent/` inside a container running a single jvm process as user `daemon`, create a perf-map in the container's `/tmp` as follows:
```
docker exec -it --user daemon CONTAINER sh -c '/perf-map-agent/bin/create-java-perf-map.sh $(pidof java)'
```
NB: the pid of the perf map will be the pid in the container's namespace, not the host's.

hopefully addresses concerns in https://github.com/jvm-profiling-tools/perf-map-agent/pull/18