### PR TITLE
Support for JDK 9+.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,12 @@ INCLUDE_DIRECTORIES(${JAVA_INCLUDE_PATH2})
 
 add_library(perfmap SHARED src/c/perf-map-agent.c src/c/perf-map-file.c)
 
-find_package(Java REQUIRED)
+find_package(Java COMPONENTS Development)
+if (Java_Development_FOUND)
+    message("Java development tools found.")
+else()
+    message(FATAL_ERROR "Java development tools not found.")
+endif()
 include(UseJava)
 
 set(CMAKE_JAVA_INCLUDE_PATH ${JAVA_INCLUDE_PATH}/../lib/tools.jar)

--- a/bin/create-java-perf-map.sh
+++ b/bin/create-java-perf-map.sh
@@ -36,11 +36,17 @@ fi
 [ -d "$JAVA_HOME" ] || (echo "JAVA_HOME directory at '$JAVA_HOME' does not exist." && false)
 
 
+if [ -f "$JAVA_HOME/lib/tools.jar" ]; then
+    JAVA_CLASSPATH="-cp $JAVA_HOME/lib/tools.jar"
+else
+    JAVA_CLASSPATH="--add-modules jdk.attach"
+fi
+
 if [[ "$LINUX" == "1" ]]; then
   sudo rm $PERF_MAP_FILE -f
-  (cd $PERF_MAP_DIR/out && sudo -u \#$TARGET_UID -g \#$TARGET_GID $JAVA_HOME/bin/java -cp $ATTACH_JAR_PATH:$JAVA_HOME/lib/tools.jar net.virtualvoid.perf.AttachOnce $PID "$OPTIONS")
+  (cd $PERF_MAP_DIR/out && sudo -u \#$TARGET_UID -g \#$TARGET_GID $JAVA_HOME/bin/java $JAVA_CLASSPATH -jar $ATTACH_JAR_PATH $PID "$OPTIONS")
   sudo chown root:root $PERF_MAP_FILE
 else
   rm -f $PERF_MAP_FILE
-  (cd $PERF_MAP_DIR/out && $JAVA_HOME/bin/java -cp $ATTACH_JAR_PATH:$JAVA_HOME/lib/tools.jar net.virtualvoid.perf.AttachOnce $PID "$OPTIONS")
+  (cd $PERF_MAP_DIR/out && $JAVA_HOME/bin/java $JAVA_CLASSPATH -jar $ATTACH_JAR_PATH $PID "$OPTIONS")
 fi


### PR DESCRIPTION
This solves #42 by adding minimal support for JDK 9 and later versions.
Issues addressed are:

- lack of tools.jar since JDK 9 (replaced by adding `jdk.attach` module)
- lack of javah since JDK 10 (now handled by javac, so no longer required)