### PR TITLE
Allow perf-map-agent to be loaded at startup

### DIFF
--- a/src/c/perf-map-agent.c
+++ b/src/c/perf-map-agent.c
@@ -337,6 +337,21 @@ jvmtiError set_callbacks(jvmtiEnv *jvmti) {
     return (*jvmti)->SetEventCallbacks(jvmti, &callbacks, (jint)sizeof(callbacks));
 }
 
+JNIEXPORT jint JNICALL 
+Agent_OnLoad(JavaVM *vm, char *options, void *reserved)
+{
+    open_map_file();
+
+    jvmtiEnv *jvmti;
+    (*vm)->GetEnv(vm, (void **)&jvmti, JVMTI_VERSION_1);
+    enable_capabilities(jvmti);
+    set_callbacks(jvmti);
+    set_notification_mode(jvmti, JVMTI_ENABLE);
+
+    return 0;
+}
+
+
 JNIEXPORT jint JNICALL
 Agent_OnAttach(JavaVM *vm, char *options, void *reserved) {
     open_map_file();


### PR DESCRIPTION
Implemented Agent_OnLoad so that the agent may be loaded at startup.
Previously the agent could only be attached at runtime.

The agent may be loaded using the following cmd line syntax:
perf record java -XX:+PreserveFramePointer -agentpath:/path/to/perf-map-agent/out/libperfmap.so app args